### PR TITLE
[WIP] POC with GO-AOP instead of AOP PHP

### DIFF
--- a/.atoum.bootstrap.php
+++ b/.atoum.bootstrap.php
@@ -1,3 +1,30 @@
 <?php
 
+use Go\Aop\Features;
+use Rezzza\TimeTravelerAspectKernel;
+
 require_once  __DIR__.'/vendor/autoload.php';
+
+
+
+// Initialize an application aspect container
+$applicationAspectKernel = TimeTravelerAspectKernel::getInstance();
+$defaultFeatures = TimeTravelerAspectKernel::getDefaultFeatures();
+$cacheDirectory = __DIR__ . '/tests/units/cache/go-aop';
+
+if (!is_dir($cacheDirectory) && strlen($cacheDirectory) > 0) {
+    mkdir($cacheDirectory, 0700, true);
+}
+
+$applicationAspectKernel->init(array(
+    'debug' => true, // use 'false' for production mode
+    // Cache directory
+    'cacheDir' => $cacheDirectory,
+    // Include paths restricts the directories where aspects should be applied, or empty for all source files
+    'includePaths' => array(
+//                __DIR__ . '/tests/units'
+    ),
+    // Enable function interception
+//            'interceptFunctions' => true,
+    'features' => $defaultFeatures | Features::INTERCEPT_FUNCTIONS,
+));

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "atoum/atoum": "dev-master"
     },
     "suggest": {
-        "ext-aop" : "To enable the time traveler and use this library."
+        "ext-aop" : "To enable the time traveler and use this library.",
+        "goaop/framework" : "To enable the time traveler and use this library."
     },
     "autoload":     {
         "psr-4": { "Rezzza\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "homepage": "https://github.com/rezzza/TimeTraveler/contributors"
     }],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "goaop/framework": "^1.0@dev"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"
@@ -21,6 +22,9 @@
     },
     "autoload":     {
         "psr-4": { "Rezzza\\": "src/" }
+    },
+    "autoload-dev":     {
+        "psr-4": { "Rezzza\\Tests\\Units\\Stubs\\": "tests/units/stubs/" }
     },
     "config": {
         "bin-dir": "bin"

--- a/src/TimeTravelerAspect.php
+++ b/src/TimeTravelerAspect.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Rezzza;
+
+use Go\Aop\Aspect;
+use Go\Aop\Intercept\FunctionInvocation;
+use Go\Aop\Intercept\MethodInvocation;
+use Go\Lang\Annotation\After;
+use Go\Lang\Annotation\Before;
+use Go\Lang\Annotation\Around;
+use Go\Lang\Annotation\Pointcut;
+use Go\Aop\Intercept\FieldAccess;
+
+/**
+ * @author Guillaume MOREL <guillaume.morel@verylastroom.com>
+ */
+class TimeTravelerAspect implements Aspect
+{
+   /**
+     * @param FunctionInvocation $invocation
+     *
+     * @Around("execution(**\time(*))")
+     *
+     * @return int
+     */
+    public function aroundTimeFunction(FunctionInvocation $invocation)
+    {
+        echo 'Calling Around Interceptor for function: ',
+            $invocation->getFunction()->getName(),
+            '()',
+            ' with arguments: ',
+            json_encode($invocation->getArguments()),
+            PHP_EOL;
+
+        return 12345;
+    }
+
+    /**
+     * @param MethodInvocation $invocation
+     *
+     * @Around("execution(public Rezzza\Tests\Units\Stubs\Test->format(*))")
+     *
+     * @return string
+     */
+    public function aroundTestDateTimeFormatMethod(MethodInvocation $invocation)
+    {
+        $obj = $invocation->getThis();
+        echo 'Calling Around Interceptor for method: ',
+             is_object($obj) ? get_class($obj) : $obj,
+             $invocation->getMethod()->isStatic() ? '::' : '->',
+             $invocation->getMethod()->getName(),
+             '()',
+             ' with arguments: ',
+             json_encode($invocation->getArguments()),
+             "<br>\n";
+
+        return 'overridden_format';
+    }
+
+    /**
+     * @param MethodInvocation $invocation
+     *
+     * @Around("execution(public DateTime->format(*))")
+     *
+     * @return string
+     */
+    public function aroundNativeDateTimeFormatMethod(MethodInvocation $invocation)
+    {
+        $obj = $invocation->getThis();
+        echo 'Calling Around Interceptor for method: ',
+             is_object($obj) ? get_class($obj) : $obj,
+             $invocation->getMethod()->isStatic() ? '::' : '->',
+             $invocation->getMethod()->getName(),
+             '()',
+             ' with arguments: ',
+             json_encode($invocation->getArguments()),
+             "<br>\n";
+
+        return 'overridden_format';
+    }
+}

--- a/src/TimeTravelerAspectKernel.php
+++ b/src/TimeTravelerAspectKernel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rezzza;
+
+use Go\Core\AspectKernel;
+use Go\Core\AspectContainer;
+
+/**
+ * @author Guillaume MOREL <guillaume.morel@verylastroom.com>
+ */
+class TimeTravelerAspectKernel extends AspectKernel
+{
+    /**
+     * Configure an AspectContainer with advisors, aspects and pointcuts
+     *
+     * @param AspectContainer $container
+     *
+     * @return void
+     */
+    protected function configureAop(AspectContainer $container)
+    {
+        $container->registerAspect(new TimeTravelerAspect());
+    }
+}

--- a/tests/units/Rezzza/TimeTravelerAspect.php
+++ b/tests/units/Rezzza/TimeTravelerAspect.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace tests\units\Rezzza;
+
+use mageekguy\atoum;
+use Rezzza\Tests\Units\Stubs\Test;
+
+class TimeTravelerAspect extends atoum\test
+{
+    public function test_override_custom_object_method()
+    {
+        $stub = new Test();
+
+        $this->string($stub->format())->isEqualTo('overridden_format');
+    }
+
+    public function test_time_native_function()
+    {
+        $stub = new Test();
+
+        $this->integer($stub->returnTimeFunctionResult())->isEqualTo(12345);
+    }
+
+    /**
+     * Fails unfortunately
+     */
+    public function test_datetime_native_format_method()
+    {
+        $stub = new Test();
+
+        $this->string($stub->returnNativeDateTimeFormatMethodResult())->isEqualTo('overridden_format');
+    }
+}

--- a/tests/units/stubs/Test.php
+++ b/tests/units/stubs/Test.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rezzza\Tests\Units\Stubs;
+
+/**
+ * @author Guillaume MOREL <guillaume.morel@verylastroom.com>
+ */
+class Test
+{
+    /**
+     * Call for native function `time()`
+     *
+     * @return int
+     */
+    public function returnTimeFunctionResult()
+    {
+        return time();
+    }
+
+    /**
+     * Call for native `DateTime->format()` method
+     *
+     * @return string
+     */
+    public function returnNativeDateTimeFormatMethodResult()
+    {
+        $dateTime = new \DateTime();
+
+        return $dateTime->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Call for custom Object method
+     *
+     * @return string
+     */
+    public function format()
+    {
+        return 'expected_format';
+    }
+}


### PR DESCRIPTION
Rebund of https://github.com/rezzza/TimeTraveler/issues/21
#### Proof of Concept

As a fundation to allow us injecting time. We need to validate GO-AOP behaviour for:
- PHP native function `time()`
- PHP native object `\DateTime` 
#### Status
- Overriding custom object method is **OK**
- Overriding native `time()` is **OK**
- Overriding native `DateTime()->format()` is **Not working**
- Overriding native `DateTime::__construct` is **Not yet tested**

As if the [Pointcut](http://go.aopphp.com/docs/pointcut-reference/) `@Around("execution(public DateTime->format(*))")` were ignored (nothing built in the cache directory either)
#### Test

You can run the test via 

> bin/atoum tests/units/Rezzza/TimeTravelerAspect.php
